### PR TITLE
Update README branding: “Arch Configured. Built at UT.”

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://github.com/uta-lug-nuts/LnOS/blob/main/docs/images/Tux_with_toolbox.png?raw=true" width=50% alt="tux with toolbox"></center>
 
-# 🔐 LnOS a Customized Arch Distro tailored to UTA Students
+# 🔐 LnOS — Arch Configured. Built at UT.
 
 ![GPG Signed](https://img.shields.io/badge/GPG-Signed-brightgreen?style=for-the-badge&logo=gnupg)
 ![Security Verified](https://img.shields.io/badge/Security-Verified-blue?style=for-the-badge&logo=shield)
@@ -13,7 +13,7 @@
 "A UTA flavored distro with all the applications and tools the different engineering majors use" - Professor Bakker
 
 ## Overview
-The-LN-Project is a custom Linux distribution based on Arch Linux, designed specifically for University of Texas at Arlington (UTA) students. It aims to provide a lightweight, flexible, and powerful environment tailored to the needs of engineering students.The distro supports both x86_64 and ARM architectures (e.g., Raspberry Pi), ensuring compatibility with a wide range of student hardware.
+The-LN-Project is a custom Linux distribution based on Arch Linux, originally designed for University of Texas at Arlington (UTA) students. It aims to provide a lightweight, flexible, and powerful environment tailored to the needs of engineering students.The distro supports both x86_64 and ARM architectures (e.g., Raspberry Pi), ensuring compatibility with a wide range of student hardware.
 
 * First focused discipline is Computer Science (CS). 
 


### PR DESCRIPTION
## Summary
This PR updates the project README with a fresh tagline of who LnOS is for.

- New headline: **“LnOS — Arch Configured. Built at UT.”**
- Updated wording to say LnOS **is originally designed for UTA students**, while still highlighting support for x86_64 and ARM (like Raspberry Pi).

## Why
- Gives the project a stronger identity for flyers, tabling, and online presence.
- Makes it clear that LnOS is a UTA-based student project, but open for the wider community.
- Keeps the README welcoming with source tree Linux and Arch Linux-level marketing and advertising (shout out to our marking and advertising majors)

## Scope
- Docs only — no code, build, or workflow changes.
- Just branding and overview text in `docs/README.md`.

## Possible enhancements
- Add a short “Who is LnOS for?” section to help new folks see where they fit.
- Explore a quick “Contributing” callout so designers, writers, and community members who are interested can cook (the bots suggested this. I added cook)

---